### PR TITLE
強制発火するようにpos.pyとtanabota.pyを修正しました

### DIFF
--- a/routers/pos.py
+++ b/routers/pos.py
@@ -1,7 +1,7 @@
 # routers/pos.py  —— 認可ヘッダなし（デモ用）
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, conint
@@ -26,6 +26,8 @@ def get_db():
 class ExecuteRequest(BaseModel):
     user_id: int = Field(..., ge=1)
     amount: conint(ge=0, le=999_999_999_999)
+    # 追加: カテゴリを任意指定（カテゴリ依存トリガー用）
+    category: Optional[str] = Field(None, description="支出カテゴリ（例: 'コンビニ', 'エンタメ', '推し活' など）")
 
 class ExecutionItem(BaseModel):
     rule_id: int
@@ -60,6 +62,7 @@ def execute(request: ExecuteRequest, db: Session = Depends(get_db)):
             db,
             user_id=request.user_id,
             amount_paid=int(request.amount),
+            category=request.category,  # ← 追加
         )
         db.commit()
     except HTTPException:


### PR DESCRIPTION
# 目的

* **POSデモ時の“必ず発火”を保証**：ユーザーがどのレシピを選んでも、POSで決済すると最低1件のルールが発火し、結果がUI/ログに必ず出る状態を実現。

# 主要改修（コード）

1. **POS APIにカテゴリ任意指定を追加**（`routers/pos.py`）

   * `POST /pos/execute` のリクエストに `category: Optional[str]` を追加。
   * カテゴリ依存のトリガー（例：「特定カテゴリでの支出」「推し活同額ミラーリング」）を**明示指定で確実に発火**可能に。
   * 既存クライアントは未指定でも動作（**後方互換**）。

2. **デモ用フォールバック（強制発火）を実装**（`services/tanabota.py`）

   * 通常評価で1件もマッチしなかった場合に、以下の優先順位で**必ず1件**を発火:

     1. 無条件に近い「支出発生」
     2. カテゴリ系（定義内の1件を自動選択して補完）
     3. ガチャ（確率トリガー）を**1回だけ強制成功**
     4. 条件付き支出（現在の金額で成立するもの）
   * フォールバック時はログに `{"demo_forced_fire": true, ...}` を格納し、**デモによる発火であることを可視化**。
   * 金額算出は既存ロジックを流用し、0円になる場合は\*\*安全策として1%（最低1円）\*\*を適用。

3. **トリガー判定／金額算出の堅牢化**

   * `trigger_match()`：カテゴリ条件や閾値、確率の扱いを明確化。
   * `compute_amount()`：割合／固定額／差額ペナルティ／ランダム等、既存シードの多様なパラメータ表現に対応。

※ **Seedデータ（`seeds/data.py`）は未変更**。前回PRでseeds側の設定は修正済。今回はアプリ層の改善で“必ず発火”を担保し、将来のレシピ追加にも強い構成に。

# 期待効果

* **デモ体験の一貫性**：どのレシピでも決済→**発火率100%**（デモ時）。
* **検証の生産性向上**：カテゴリ系・確率系のレシピでも毎回結果が得られ、UI/ログ確認が容易。
* **安全性**：本番判定ロジックは従来通り。フォールバック発火はログで判別可能。

# リスクと対策

* **リスク**：フォールバックにより、設定不備が**デモで気づきにくくなる**可能性。
  **対策**：ダッシュボードで `demo_forced_fire` 件数を監視、閾値超過で警告。